### PR TITLE
enable manual workflow dispatch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,7 @@ name: Build
 
 # Controls when the workflow will run
 on:
+  workflow_dispatch:
   push:
     tags:
       - 'v*.*.*'


### PR DESCRIPTION
The last commit was not tagged so it did not update the github container registry. This enables manual workflow dispatch so that the build workflow can be triggered through a browser.

An example of a successful run: https://github.com/scrivy/aws-route53-dynamic-update/actions/runs/15241398178